### PR TITLE
Changed moveRCLift to moveLiftToPos

### DIFF
--- a/src/org/usfirst/frc/team166/robot/commands/lifts/MoveLiftToPos.java
+++ b/src/org/usfirst/frc/team166/robot/commands/lifts/MoveLiftToPos.java
@@ -3,16 +3,17 @@ package org.usfirst.frc.team166.robot.commands.lifts;
 import edu.wpi.first.wpilibj.command.Command;
 
 import org.usfirst.frc.team166.robot.Robot;
+import org.usfirst.frc.team166.robot.subsystems.Lift;
 
 /**
  *
  */
-public class MoveRCLiftToPos extends Command {
+public class MoveLiftToPos extends Command {
 
 	private double liftPosition;
 
-	public MoveRCLiftToPos(double position) {
-		requires(Robot.rcLift);
+	public MoveLiftToPos(Lift lift, double position) {
+		requires(lift);
 		liftPosition = position;
 	}
 


### PR DESCRIPTION
The move lift command now takes a lift as an argument and can be called for either lift.